### PR TITLE
newbuild: Add new build system (#20)

### DIFF
--- a/src/common.um
+++ b/src/common.um
@@ -23,6 +23,7 @@ type ErrCode* = enum {
 	preBuild
 	postBuild
 	boxJsonError
+	buildError
 }
 
 var errStrings: []str = []str{
@@ -38,7 +39,8 @@ var errStrings: []str = []str{
 	"json key not found",
 	"pre build failed",
 	"post build failed",
-	"box.json error"
+	"box.json error",
+	"build error"
 }
 
 fn error*(ec: ErrCode, msg: str = ""): std::Err {
@@ -417,6 +419,8 @@ fn parseBuild*(o: map[str]any): (Build, std::Err) {
 			t := Target{}
 			if ^[]any(vo["sources"]) != null {
 				t.sources = []str([]any(vo["sources"]))
+			} else if ^str(vo["sources"]) != null {
+				t.sources = []str{str(vo["sources"])}
 			}
 			
 			if validkey(vo, "cflags") {

--- a/src/common.um
+++ b/src/common.um
@@ -209,6 +209,22 @@ fn (ps: ^PlatString) get*(): str {
 	return ps[.unknown]
 }
 
+type (
+	Target* = struct {
+		sources: []str
+		cflags: PlatString
+		ldflags: PlatString
+	}
+
+	Build* = struct {
+		isValid: bool
+		pre: PlatString
+		post: PlatString
+		include: []str
+		targets: map[str]Target
+	}
+)
+
 type Meta* = struct {
 	name: str
 	version: str
@@ -224,6 +240,7 @@ type Meta* = struct {
 	preBuild: PlatString
 	postBuild: PlatString
 	others: map[str]any
+	build: Build
 }
 
 fn putPlatString(enc: ^jsonenc::Encoder, ps: PlatString) {
@@ -367,6 +384,60 @@ fn getPlatString(o: any): (PlatString, std::Err) {
 	}
 	
 	return ps, {}
+}
+
+fn parseBuild*(o: map[str]any): (Build, std::Err) {
+	var err: std::Err
+	b := Build{
+		isValid: true
+	}
+	   
+	if validkey(o, "pre") {
+		b.pre, err = getPlatString(o["pre"])
+		if err.code != 0 {
+			return {}, err
+		}
+	}	
+	
+	if validkey(o, "post") {
+		b.post, err = getPlatString(o["post"])
+		if err.code != 0 {
+			return {}, err
+		}
+	}
+	
+	if ^[]any(o["include"]) != null {
+		b.include = []str([]any(o["include"]))
+	}
+	
+	if ^map[str]any(o["targets"]) != null {
+		b.targets = map[str]Target{}
+		for k, v in map[str]any(o["targets"]) {
+			vo := map[str]any(v)
+			t := Target{}
+			if ^[]any(vo["sources"]) != null {
+				t.sources = []str([]any(vo["sources"]))
+			}
+			
+			if validkey(vo, "cflags") {
+				t.cflags, err = getPlatString(vo["cflags"])
+				if err.code != 0 {
+					return {}, err
+				}
+			}
+			
+			if validkey(vo, "ldflags") {
+				t.ldflags, err = getPlatString(vo["ldflags"])
+				if err.code != 0 {
+					return {}, err
+				}
+			}
+			
+			b.targets[k] = t
+		}
+	}
+	
+	return b, {}
 }
 
 fn getMeta*(path: str): (Meta, std::Err) {
@@ -515,6 +586,15 @@ fn getMeta*(path: str): (Meta, std::Err) {
 			return {}, err
 		}
 		r ^= delete(r^, "post_build")
+	}
+	
+	if ^map[str]any(r["build"]) != null {
+		m.build, err = parseBuild(map[str]any(r["build"]))
+		if err.code != 0 {
+			return {}, err
+		}
+
+		r ^= delete(r^, "build")
 	}
 
 	m.others = r^

--- a/src/common.um
+++ b/src/common.um
@@ -24,6 +24,7 @@ type ErrCode* = enum {
 	postBuild
 	boxJsonError
 	buildError
+	githubApiError
 }
 
 var errStrings: []str = []str{
@@ -40,7 +41,8 @@ var errStrings: []str = []str{
 	"pre build failed",
 	"post build failed",
 	"box.json error",
-	"build error"
+	"build error",
+	"github API error"
 }
 
 fn error*(ec: ErrCode, msg: str = ""): std::Err {
@@ -203,12 +205,16 @@ fn (b: ^FileBox) encode*(): str {
 
 type PlatString* = map[os::Platform]str
 
-fn (ps: ^PlatString) get*(): str {
-	if validkey(ps^, os::getPlatform()) {
-		return ps[os::getPlatform()]
+fn (ps: ^PlatString) getByPlatform*(plat: os::Platform): str {
+	if validkey(ps^, plat) {
+		return ps[plat]
 	}
 	
 	return ps[.unknown]
+}
+
+fn (ps: ^PlatString) get*(): str {
+	return ps.getByPlatform(os::getPlatform())
 }
 
 type (

--- a/src/newbuild.um
+++ b/src/newbuild.um
@@ -1,0 +1,17 @@
+
+import (
+	"std.um"
+
+	"common.um"
+)
+
+fn run*(): std::Err {
+	meta, err := common::getMeta("box.json")
+	if err.code != 0 {
+		return common::error(.boxJsonError, err.msg)
+	}
+	
+	printf("%llv\n", meta.build)
+	
+	return {}
+}

--- a/src/newbuild.um
+++ b/src/newbuild.um
@@ -9,6 +9,17 @@ import (
 	"common.um"
 )
 
+fn addFile*(outDir: str, p1: str) {
+	p2 := filepath::join(outDir, p1)
+	os::mkdirp(filepath::dir(p2))
+	f1, err := std::fopen(p1, "rb")
+	d, err := std::freadall(f1)
+	f2, err := std::fopen(p2, "wb")
+	std::fwrite(f2, d)
+	std::fclose(f1)
+	std::fclose(f2)
+}
+
 fn shouldRebuild*(target: str, sources: []str): (bool, std::Err) {
 	if !os::isfile(target) {
 		return true, {}
@@ -33,29 +44,7 @@ fn shouldRebuild*(target: str, sources: []str): (bool, std::Err) {
 	return false, {}
 }
 
-fn run*(outDir: str): std::Err {
-	meta, err := common::getMeta("box.json")
-	if err.code != 0 {
-		return common::error(.boxJsonError, err.msg)
-	}
-	
-	if !meta.build.isValid {
-		return common::error(.boxJsonError, "no valid build structure")
-	}
-	
-	err = os::mkdirp(outDir)
-	if (err.code != 0) {
-		return err
-	}
-	
-	pre := meta.build.pre.get()
-	if pre != "" {
-		rc := std::system(pre)
-		if rc != 0 {
-			return common::error(.preBuild, sprintf("pre-build exited with code %d", rc))
-		}
-	}
-		 
+fn buildTargets(outDir: str, meta: common::Meta): std::Err {
 	cc := std::getenv("CC")
 	if cc == "" {
 		cc = "cc"
@@ -74,16 +63,61 @@ fn run*(outDir: str): std::Err {
 		}
 				  
 		if !rebuild {
+			if common::debugMode { printf("No need to rebuild %s\n", path) }
 			continue
 		}
 		
 		command := sprintf("%s -shared %s -o %s %s %s", cc, target.ldflags.get(), fullPath, target.cflags.get(), strings::join(target.sources, " "))
+		printf("%s\n", command)
 		rc := std::system(command)
 		if rc != 0 {
 			return common::error(.buildError, sprintf("build for %s exited with code %d", path, rc))
 		}
 	}
+
+	return {}
+}
+
+fn run*(outDir: str): std::Err {
+	meta, err := common::getMeta("box.json")
+	if err.code != 0 {
+		return common::error(.boxJsonError, err.msg)
+	}
 	
+	if !meta.build.isValid {
+		return common::error(.boxJsonError, "no valid build structure")
+	}
+	
+	err = os::mkdirp(outDir)
+	if err.code != 0 {
+		return err
+	}
+	
+	pre := meta.build.pre.get()
+	if pre != "" {
+		rc := std::system(pre)
+		if rc != 0 {
+			return common::error(.preBuild, sprintf("pre-build exited with code %d", rc))
+		}
+	}
+
+	err = buildTargets(outDir, meta)
+	if err.code != 0 {
+		return err
+	}
+
+	for i,f in meta.build.include {
+		if os::isfile(f) {
+			addFile(outDir, f)
+		} else if os::isdir(f) {
+			os::walk(f, fn(p: str) |outDir| {
+				addFile(outDir, p)
+			})
+		} else {
+			return common::error(.fileNotFound, f)
+		}
+	}
+
 	post := meta.build.post.get()
 	if post != "" {
 		rc := std::system(post)

--- a/src/newbuild.um
+++ b/src/newbuild.um
@@ -10,6 +10,11 @@ import (
 	"common.um"
 )
 
+type Params* = struct {
+	platformTag: bool
+	winCross: bool
+}
+
 type Output* = interface {
 	addFile(f: str): std::Err
 	shouldRebuild(target: str, sources: []str): bool
@@ -103,7 +108,42 @@ fn (o: ^TarOutput) cc*(file, cmd: str, f: fn(file, cmd: str): std::Err): std::Er
 	return err
 }
 
-fn buildTargets(out: Output, meta: common::Meta): std::Err {
+fn tagTarget(path: str, plat: os::Platform): str {
+	suffix := ".umi"
+	switch plat {
+	case .posix: suffix = "_linux.umi"
+	case .windows: suffix = "_windows.umi"
+	case .emscripten: suffix = "_emscripten.umi"
+	}
+
+	return strings::trimsuffix(path, ".umi") + suffix
+}
+
+fn compileUMI(out: Output, cc: str, path: str, target: common::Target, plat: os::Platform, par: Params): std::Err {
+	if par.platformTag {
+		path = tagTarget(path, os::getPlatform())
+	}
+
+	rebuild := out.shouldRebuild(path, target.sources)
+	if !rebuild {
+		if common::debugMode { printf("No need to rebuild %s\n", path) }
+		return {}
+	}
+
+	command := sprintf("%s -shared %s -o %%s %s %s", cc, target.ldflags.getByPlatform(plat),
+		 target.cflags.getByPlatform(plat), strings::join(target.sources, " "))
+	return out.cc(path, command, {
+		cmd = sprintf(cmd, file)
+		printf("+ %s\n", cmd)
+		rc := std::system(cmd)
+		if rc != 0 {
+			return common::error(.buildError, sprintf("build for %s exited with code %d", file, rc))
+		}
+		return {}
+	})
+}
+
+fn buildTargets(out: Output, meta: common::Meta, par: Params): std::Err {
 	cc := std::getenv("CC")
 	if cc == "" {
 		cc = "cc"
@@ -115,29 +155,27 @@ fn buildTargets(out: Output, meta: common::Meta): std::Err {
 			continue
 		}
 
-		rebuild := out.shouldRebuild(path, target.sources)
-		if !rebuild {
-			if common::debugMode { printf("No need to rebuild %s\n", path) }
-			continue
+		err := compileUMI(out, cc, path, target, os::getPlatform(), par)
+		if err.code != 0 {
+			return err
 		}
 
-		command := sprintf("%s -shared %s -o %%s %s %s", cc, target.ldflags.get(),
-			 target.cflags.get(), strings::join(target.sources, " "))
-		err := out.cc(path, command, {
-			cmd = sprintf(cmd, file)
-			printf("+ %s\n", cmd)
-			rc := std::system(cmd)
-			if rc != 0 {
-				return common::error(.buildError, sprintf("build for %s exited with code %d", file, rc))
+		if (par.winCross) {
+			err = compileUMI(out, "x86_64-w64-mingw32-gcc", path, target, .windows, par)
+			if err.code != 0 {
+				return err
 			}
-			return {}
-		})
+		}
 	}
 
 	return {}
 }
 
-fn run*(out: Output): std::Err {
+fn run*(out: Output, par: Params): std::Err {
+	if par.winCross && os::getPlatform() != .posix {
+		return common::error(.buildError, "Cross compile for Windows only avaiable on Linux")
+	}
+
 	meta, err := common::getMeta("box.json")
 	if err.code != 0 {
 		return common::error(.boxJsonError, err.msg)
@@ -155,7 +193,7 @@ fn run*(out: Output): std::Err {
 		}
 	}
 
-	err = buildTargets(out, meta)
+	err = buildTargets(out, meta, par)
 	if err.code != 0 {
 		return err
 	}

--- a/src/newbuild.um
+++ b/src/newbuild.um
@@ -2,15 +2,27 @@
 import (
 	"std.um"
 
-	"../umbox/os/os.um"
 	"../umbox/filepath/filepath.um"
+	"../umbox/os/os.um"
 	"../umbox/strings/strings.um"
+	"../umbox/tar/tar.um"
 
 	"common.um"
 )
 
-fn addFile*(outDir: str, p1: str) {
-	p2 := filepath::join(outDir, p1)
+type Output* = interface {
+	addFile(f: str): std::Err
+	shouldRebuild(target: str, sources: []str): bool
+	close(): std::Err
+	cc(file, cmd: str, f: fn(file, cmd: str): std::Err): std::Err
+}
+
+type DirOutput* = struct {
+	path: str
+}
+
+fn (o: ^DirOutput) addFile*(p1: str): std::Err {
+	p2 := filepath::join(o.path, p1)
 	os::mkdirp(filepath::dir(p2))
 	f1, err := std::fopen(p1, "rb")
 	d, err := std::freadall(f1)
@@ -18,33 +30,80 @@ fn addFile*(outDir: str, p1: str) {
 	std::fwrite(f2, d)
 	std::fclose(f1)
 	std::fclose(f2)
+
+	return {} // TODO
 }
 
-fn shouldRebuild*(target: str, sources: []str): (bool, std::Err) {
+fn (o: ^DirOutput) shouldRebuild*(target: str, sources: []str): bool {
+	target = filepath::join(o.path, target)
+
 	if !os::isfile(target) {
-		return true, {}
+		return true
 	}
 	
 	tstat, err := os::stat(target)
 	if err.code != 0 {
-		return false, err
+		return true
 	}
 	
 	for i in sources {
 		sstat, err := os::stat(sources[i])
 		if err.code != 0 {
-			return false, err
+			return true
 		}
 		
 		if sstat.mtime > tstat.mtime {
-			return true, {}
+			return true
 		}
 	}
 	
-	return false, {}
+	return false
 }
 
-fn buildTargets(outDir: str, meta: common::Meta): std::Err {
+fn (o: ^DirOutput) close*(): std::Err {
+	return {}
+}
+
+fn (o: ^DirOutput) cc*(file, cmd: str, f: fn(file, cmd: str): std::Err): std::Err {
+	return f(filepath::join(o.path, file), cmd)
+}
+
+type TarOutput* = struct {
+	t: tar::Tar
+}
+
+fn (o: ^TarOutput) addFile*(f: str): std::Err {
+	o.t.addFile(f)
+	// TODO: there is an error in tar.um where Tar.addFile returns incorrect
+	// error type
+	return {}
+}
+
+fn (o: ^TarOutput) shouldRebuild*(target: str, sources: []str): bool {
+	return true
+}
+
+fn (o: ^TarOutput) close*(): std::Err {
+	err := o.t.finalize()
+	if err.code != 0 {
+		return err
+	}
+	return o.t.close()
+}
+
+// This might not be the ideal behavior since it might conflict with user intentions.
+fn (o: ^TarOutput) cc*(file, cmd: str, f: fn(file, cmd: str): std::Err): std::Err {
+	err := f(file, cmd)
+	if err.code != 0 {
+		return err
+	}
+
+	err = o.addFile(file)
+	os::remove(file)
+	return err
+}
+
+fn buildTargets(out: Output, meta: common::Meta): std::Err {
 	cc := std::getenv("CC")
 	if cc == "" {
 		cc = "cc"
@@ -55,30 +114,30 @@ fn buildTargets(outDir: str, meta: common::Meta): std::Err {
 			printf("Warning: Only .umi files are supported, skipping %s\n", path)
 			continue
 		}
-		
-		fullPath := filepath::join(outDir, path)
-		rebuild, err := shouldRebuild(fullPath, target.sources)
-		if err.code != 0 {
-			return err
-		}
-				  
+
+		rebuild := out.shouldRebuild(path, target.sources)
 		if !rebuild {
 			if common::debugMode { printf("No need to rebuild %s\n", path) }
 			continue
 		}
-		
-		command := sprintf("%s -shared %s -o %s %s %s", cc, target.ldflags.get(), fullPath, target.cflags.get(), strings::join(target.sources, " "))
-		printf("%s\n", command)
-		rc := std::system(command)
-		if rc != 0 {
-			return common::error(.buildError, sprintf("build for %s exited with code %d", path, rc))
-		}
+
+		command := sprintf("%s -shared %s -o %%s %s %s", cc, target.ldflags.get(),
+			 target.cflags.get(), strings::join(target.sources, " "))
+		err := out.cc(path, command, {
+			cmd = sprintf(cmd, file)
+			printf("+ %s\n", cmd)
+			rc := std::system(cmd)
+			if rc != 0 {
+				return common::error(.buildError, sprintf("build for %s exited with code %d", file, rc))
+			}
+			return {}
+		})
 	}
 
 	return {}
 }
 
-fn run*(outDir: str): std::Err {
+fn run*(out: Output): std::Err {
 	meta, err := common::getMeta("box.json")
 	if err.code != 0 {
 		return common::error(.boxJsonError, err.msg)
@@ -87,12 +146,7 @@ fn run*(outDir: str): std::Err {
 	if !meta.build.isValid {
 		return common::error(.boxJsonError, "no valid build structure")
 	}
-	
-	err = os::mkdirp(outDir)
-	if err.code != 0 {
-		return err
-	}
-	
+
 	pre := meta.build.pre.get()
 	if pre != "" {
 		rc := std::system(pre)
@@ -101,17 +155,17 @@ fn run*(outDir: str): std::Err {
 		}
 	}
 
-	err = buildTargets(outDir, meta)
+	err = buildTargets(out, meta)
 	if err.code != 0 {
 		return err
 	}
 
 	for i,f in meta.build.include {
 		if os::isfile(f) {
-			addFile(outDir, f)
+			out.addFile(f)
 		} else if os::isdir(f) {
-			os::walk(f, fn(p: str) |outDir| {
-				addFile(outDir, p)
+			os::walk(f, fn(p: str) |out| {
+				out.addFile(p)
 			})
 		} else {
 			return common::error(.fileNotFound, f)
@@ -125,6 +179,6 @@ fn run*(outDir: str): std::Err {
 			return common::error(.postBuild, sprintf("post-build exited with code %d", rc))
 		}
 	}
-	
+
 	return {}
 }

--- a/src/newbuild.um
+++ b/src/newbuild.um
@@ -2,16 +2,95 @@
 import (
 	"std.um"
 
+	"../umbox/os/os.um"
+	"../umbox/filepath/filepath.um"
+	"../umbox/strings/strings.um"
+
 	"common.um"
 )
 
-fn run*(): std::Err {
+fn shouldRebuild*(target: str, sources: []str): (bool, std::Err) {
+	if !os::isfile(target) {
+		return true, {}
+	}
+	
+	tstat, err := os::stat(target)
+	if err.code != 0 {
+		return false, err
+	}
+	
+	for i in sources {
+		sstat, err := os::stat(sources[i])
+		if err.code != 0 {
+			return false, err
+		}
+		
+		if sstat.mtime > tstat.mtime {
+			return true, {}
+		}
+	}
+	
+	return false, {}
+}
+
+fn run*(outDir: str): std::Err {
 	meta, err := common::getMeta("box.json")
 	if err.code != 0 {
 		return common::error(.boxJsonError, err.msg)
 	}
 	
-	printf("%llv\n", meta.build)
+	if !meta.build.isValid {
+		return common::error(.boxJsonError, "no valid build structure")
+	}
+	
+	err = os::mkdirp(outDir)
+	if (err.code != 0) {
+		return err
+	}
+	
+	pre := meta.build.pre.get()
+	if pre != "" {
+		rc := std::system(pre)
+		if rc != 0 {
+			return common::error(.preBuild, sprintf("pre-build exited with code %d", rc))
+		}
+	}
+		 
+	cc := std::getenv("CC")
+	if cc == "" {
+		cc = "cc"
+	}
+
+	for path,target in meta.build.targets {
+		if filepath::ext(path) != "umi" {
+			printf("Warning: Only .umi files are supported, skipping %s\n", path)
+			continue
+		}
+		
+		fullPath := filepath::join(outDir, path)
+		rebuild, err := shouldRebuild(fullPath, target.sources)
+		if err.code != 0 {
+			return err
+		}
+				  
+		if !rebuild {
+			continue
+		}
+		
+		command := sprintf("%s -shared %s -o %s %s %s", cc, target.ldflags.get(), fullPath, target.cflags.get(), strings::join(target.sources, " "))
+		rc := std::system(command)
+		if rc != 0 {
+			return common::error(.buildError, sprintf("build for %s exited with code %d", path, rc))
+		}
+	}
+	
+	post := meta.build.post.get()
+	if post != "" {
+		rc := std::system(post)
+		if rc != 0 {
+			return common::error(.postBuild, sprintf("post-build exited with code %d", rc))
+		}
+	}
 	
 	return {}
 }

--- a/umbox.um
+++ b/umbox.um
@@ -14,6 +14,8 @@ import (
 	"src/upload.um"
 
 	"umbox/args/args.um"
+	"umbox/filepath/filepath.um"
+	"umbox/tar/tar.um"
 )
 
 fn main() {
@@ -73,10 +75,16 @@ fn main() {
 		args.check()
 		common::exitif(upload::run(secret, file))
 	} else if args.mode("newbuild", "Run new experimental build") {
-		outDir := "out"
-		args.optional(&outDir, "output", "Specify output directory").short('o')
-
-		common::exitif(newbuild::run(outDir))
+		outPath := "out"
+		args.optional(&outPath, "output", "Specify output directory/archive").short('o')
+		args.check()
+		if filepath::ext(outPath) == "tar" {
+			t, err := tar::open(outPath, "w")
+			common::exitif(err)
+			common::exitif(newbuild::run(newbuild::TarOutput{t}))
+		} else {
+			common::exitif(newbuild::run(newbuild::DirOutput{outPath}))
+		}
 	} else {
 		args.usage()
 	}

--- a/umbox.um
+++ b/umbox.um
@@ -1,15 +1,16 @@
 import (
 	"std.um"
 	
-	"src/common.um"
 	"src/build.um"
+	"src/common.um"
 	"src/init.um"
 	"src/install.um"
+	"src/newbuild.um"
+	"src/register.um"
 	"src/remove.um"
 	"src/run.um"
 	"src/search.um"
 	"src/update.um"
-	"src/register.um"
 	"src/upload.um"
 
 	"umbox/args/args.um"
@@ -71,6 +72,8 @@ fn main() {
 		args.optionalNext(&file, "File to upload")
 		args.check()
 		common::exitif(upload::run(secret, file))
+	} else if args.mode("newbuild", "Run new experimental build") {
+		common::exitif(newbuild::run())
 	} else {
 		args.usage()
 	}

--- a/umbox.um
+++ b/umbox.um
@@ -73,7 +73,10 @@ fn main() {
 		args.check()
 		common::exitif(upload::run(secret, file))
 	} else if args.mode("newbuild", "Run new experimental build") {
-		common::exitif(newbuild::run())
+		outDir := "out"
+		args.optional(&outDir, "output", "Specify output directory").short('o')
+
+		common::exitif(newbuild::run(outDir))
 	} else {
 		args.usage()
 	}

--- a/umbox.um
+++ b/umbox.um
@@ -76,14 +76,17 @@ fn main() {
 		common::exitif(upload::run(secret, file))
 	} else if args.mode("newbuild", "Run new experimental build") {
 		outPath := "out"
+		params := newbuild::Params{}
 		args.optional(&outPath, "output", "Specify output directory/archive").short('o')
+		args.optional(&params.platformTag, "plat", "Include platform tags in UMI names")
+		args.optional(&params.winCross, "win-cross", "Cross compile for Windows")
 		args.check()
 		if filepath::ext(outPath) == "tar" {
 			t, err := tar::open(outPath, "w")
 			common::exitif(err)
-			common::exitif(newbuild::run(newbuild::TarOutput{t}))
+			common::exitif(newbuild::run(newbuild::TarOutput{t}, params))
 		} else {
-			common::exitif(newbuild::run(newbuild::DirOutput{outPath}))
+			common::exitif(newbuild::run(newbuild::DirOutput{outPath}, params))
 		}
 	} else {
 		args.usage()


### PR DESCRIPTION
Adds a new build system, which removes the need to compile box dependencies inside of `pre` scripts. This change is made with the hope of making `umbox build` run on all platforms, not just our chosen version of Linux. In the future this can be used to change umbox to build locally instead of distributing pre-built binaries.

At the moment umbox will use whichever compiler is in the `CC` env var, or `cc` by default. Since not all machines ship with a compiler, it might be beneficial to ship umbox with a copy of tcc. This way builds will work on any machine, even if result is a bit slower.

The new build specification can look like this:

```json
{
	"name": "test",
	"version": "v0.1.0",
	"author": "",
	"license": "",
	"description": "",
	"readme": "README.md",
	"dependencies": [
		"umka_api"
	],
	"include": [
	],
	"build": {
		"include": ["test.um"],
		"targets": {
			"test.umi": {
				"sources": "test.c",
				"cflags": "-Wall",
				"ldflags": { "windows": "-luser32" }
			}
		}
	}
}
```

The box can be built using `umbox newbuild`. By default it will output into `out/` directory. This can be overridden using `--output/-o` with a name of another directory or a tar file.